### PR TITLE
Add maven-shade-plugin to build uber jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,4 +25,30 @@
             <version>2.17.1</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <finalName>debugDemo</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>QuickStart</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Summary
- Configure maven-shade-plugin to bundle all dependencies into a single executable jar
- Set output jar name to `debugDemo.jar` (instead of `debugDemo-1.0-SNAPSHOT.jar`)
- Configure `QuickStart` as the main class in the manifest

## Test plan
- [x] Run `mvn clean package` successfully
- [x] Verify all dependencies are bundled in the jar
- [x] Verify manifest has correct Main-Class entry
- [x] Confirm jar can be executed with `java -jar target/debugDemo.jar`